### PR TITLE
Updates for 2019

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target/
 **/*.rs.bk
 Cargo.lock
+/LuaJIT-2.0.5/
+LuaJit-2.0.5.tar.gz

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ description = "System bindings for LuaJIT 2.0.5"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.31.3"
+bindgen = "0.46.0"
 gcc = "0.3"
 
 [features]
-default = ["arch_x64"]
+default = ["arch_x64","sse", "sse2"]
 
 # PLEASE CHOOSE ONLY ONE OF THE ARCHITECTURES, WILL NOT COMPILE OTHERWISE!
 arch_arm = []

--- a/build.rs
+++ b/build.rs
@@ -306,7 +306,7 @@ fn extract_tar(file: &'static str, tar: &'static str) {
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .status()
-        .map_err(|e| panic!("tar extraction failed {:?}", e));
+        .map_err(|e| panic!("tar extraction failed: {:?}", e));
 }
 
 fn build(file: &'static str, build_result: &'static str) {
@@ -326,7 +326,7 @@ fn build(file: &'static str, build_result: &'static str) {
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .status()
-        .map_err(|e| panic!("tar extraction failed {:?}", e));
+        .map_err(|e| panic!("make amalg failed: {:?}", e));
 }
 
 


### PR DESCRIPTION
### Summary

Small updates to get it working on AMD64 Fedora28

### Changes

* Enables `sse` and `sse2` by default.
  * These are part of the x64 ABI, so they're basically implied to be abled, I just included them in the default flags.
* Adds a `curl`, `tar`, and `make` invocation to `build.rs` (if they haven't been run locally).
  * The check is kind of lazy, but this removes one of more confusing steps I struggled with.

### Testing

* `cargo test` passed bingen's automatically created tests
